### PR TITLE
Fix - TextBox - Remove Unnecessary Input

### DIFF
--- a/src/embeddable.com/components/MUITextInput/MUITextInput.emb.ts
+++ b/src/embeddable.com/components/MUITextInput/MUITextInput.emb.ts
@@ -65,14 +65,6 @@ export const meta = {
       category: 'MUI Props',
       defaultValue: false,
     },
-    {
-      name: 'rows',
-      type: 'number',
-      label: 'Multiline Rows',
-      description: 'Number of rows for multiline text input',
-      category: 'MUI Props',
-      defaultValue: 3,
-    },
   ],
   events: [
     {

--- a/src/embeddable.com/components/MUITextInput/index.tsx
+++ b/src/embeddable.com/components/MUITextInput/index.tsx
@@ -13,7 +13,6 @@ interface Props {
   helperText?: string;
   multiline?: boolean;
   onChange: (v: string) => void;
-  rows?: number;
   size?:
     | OverridableStringUnion<'small' | 'medium', TextFieldPropsSizeOverrides>
     | undefined;
@@ -25,11 +24,10 @@ interface Props {
 let timeout: number | null = null;
 
 const Component: React.FC<Props> = (props: Props) => {
-  const { fullWidth, helperText, multiline, rows, size, title, variant } =
-    props;
+  const { fullWidth, helperText, multiline, size, title, variant } = props;
   const ref = useRef<HTMLInputElement | null>(null);
   const [value, setValue] = useState<string>(props.value || '');
-  const [rowsVal, setRowsVal] = useState<number>(rows || 1);
+  const [rowsVal, setRowsVal] = useState<number>(1);
 
   useEffect(() => {
     setValue(props.value || '');


### PR DESCRIPTION
Removes "rows" input that's been replaced by a resize handler. The default value of "3" was no longer doing anything, nor was changing the value. It's strictly based on the size of the Embeddable now.

**Acceptance Criteria**

- [x] Correctly remove superfluous code 
- [x] Check that resize still functions properly
- [x] Nothing is broken